### PR TITLE
Duplicate code when context is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # quiz
 
+Install the required packages:
+`cargo install mdbook; cargo install mdbook-quiz`
+
 To run locally (in dl-quiz folder):
 `mdbook serve --open`

--- a/dl-quiz/src/quiz_21.toml
+++ b/dl-quiz/src/quiz_21.toml
@@ -1,6 +1,6 @@
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ a = np.ones(5) \n$ b = trorch.from_numpy(a) \n$ print(b) \n tensor([1., 1., 1., 1., 1.], dtype=torch.float64)  </code></pre>\n What is the output of `a.dtype`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ a = np.ones(5) \n$ b = torch.from_numpy(a) \n$ print(b) \n tensor([1., 1., 1., 1., 1.], dtype=torch.float64)  </code></pre>\n What is the output of `a.dtype`?"
 prompt.choices = [
   "`float8`",
   "`float32`",
@@ -13,7 +13,7 @@ context = """
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ b = b.to(torch.uint8) \n$ a[2] = 0 \n$ b[3] = 5 </code></pre>\n What is the output of `print(b)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ a = np.ones(5) \n$ b = torch.from_numpy(a) \n$ print(b) \n tensor([1., 1., 1., 1., 1.], dtype=torch.float64)  </code></pre>\n We continue with: <pre><code class=\"language-python\"> $ b = b.to(torch.uint8) \n$ a[2] = 0 \n$ b[3] = 5 </code></pre>\n What is the output of `print(b)`?"
 prompt.choices = [
     "`[1. 1. 0. 1. 1.]`", 
     "`[1. 0. 5. 1. 1.]`",

--- a/dl-quiz/src/quiz_22.toml
+++ b/dl-quiz/src/quiz_22.toml
@@ -12,7 +12,7 @@ context = """
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with <pre><code class=\"language-python\"> $ b = b.to(device) \n$ b[0] = 2 \n$ print(b) \n tensor([2., 1., 1., 1., 1.], device='cuda:0', dtype=torch.float64) </code></pre>\n What is the output of `print(a)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ a = np.ones(5) \n$ b = torch.from_numpy(a) \n$ torch.cuda.is_available() \nTrue \n$ device = torch.device('cuda') \n$ b.to(device) </code></pre>\n We continue with <pre><code class=\"language-python\"> $ b = b.to(device) \n$ b[0] = 2 \n$ print(b) \n tensor([2., 1., 1., 1., 1.], device='cuda:0', dtype=torch.float64) </code></pre>\n What is the output of `print(a)`?"
 prompt.choices = [
   "`[2., 1., 1., 1., 1.]`",
   "`[1., 1., 1., 1., 1.]`"

--- a/dl-quiz/src/quiz_23.toml
+++ b/dl-quiz/src/quiz_23.toml
@@ -14,7 +14,7 @@ Default value is `False`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`0`",
     "`1`",
@@ -28,7 +28,7 @@ Default value is `None`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`tensor([2.])`",
     "`tensor([2., 2., 2.,  10.,  2.])`",
@@ -41,7 +41,7 @@ The derivative of each component is `2(b_i-1)`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ m = sum((b.data -1)**2) </code></pre>\n What is the output of `m.backward()`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True) $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ m = sum((b.data -1)**2) \n </code></pre>\n What is the output of `m.backward()`?"
 prompt.choices = [
     "same as for `l`",
     "`Error`"
@@ -53,7 +53,7 @@ You cannot compute gradient if you detach the `data` from the `tensor`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ n = sum((b-1)**2) \n$ n.backward() </code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True) $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ n = sum((b-1)**2) \n$ n.backward() \n $ m = sum((b.data -1)**2)</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`tensor([0., 0., 0., 8., 0.])`",
     "`tensor([0., 0., 0., 16., 0.])`"

--- a/dl-quiz/src/quiz_23.toml
+++ b/dl-quiz/src/quiz_23.toml
@@ -1,6 +1,6 @@
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)</code></pre>\n What is the output of `print(b.requires_grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)</code></pre>\n What is the output of `print(b.requires_grad)`?"
 prompt.choices = [
     "`True`", 
     "`False`",
@@ -14,7 +14,7 @@ Default value is `False`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)</code></pre>\n We continue with: <pre><code class=\"language-python\">$ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`0`",
     "`1`",
@@ -28,7 +28,7 @@ Default value is `None`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n$ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)</code></pre>\n We continue with: <pre><code class=\"language-python\">$ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`tensor([2.])`",
     "`tensor([2., 2., 2.,  10.,  2.])`",
@@ -41,7 +41,7 @@ The derivative of each component is `2(b_i-1)`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True) $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ m = sum((b.data -1)**2) \n </code></pre>\n What is the output of `m.backward()`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n$ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)\n$ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n We continue with: <pre><code class=\"language-python\">$ m = sum((b.data -1)**2) \n </code></pre>\n What is the output of `m.backward()`?"
 prompt.choices = [
     "same as for `l`",
     "`Error`"
@@ -53,7 +53,7 @@ You cannot compute gradient if you detach the `data` from the `tensor`.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We run the following code: <pre><code class=\"language-python\"> $ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n $ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True) $ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)</code></pre>\n We continue with: <pre><code class=\"language-python\"> $ n = sum((b-1)**2) \n$ n.backward() \n $ m = sum((b.data -1)**2)</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n$ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)\n$ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>) \n$ m = sum((b.data -1)**2)</code></pre>\n We continue with: <pre><code class=\"language-python\">$ n = sum((b-1)**2) \n$ n.backward() </code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`tensor([0., 0., 0., 8., 0.])`",
     "`tensor([0., 0., 0., 16., 0.])`"
@@ -65,7 +65,7 @@ Gradients are added by default.
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ n.requires_grad_(True) \n$ n.backward()</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n$ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)\n$ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>)\n$ m = sum((b.data -1)**2) \n$ n = sum((b-1)**2) \n$ n.backward() \n </code></pre>\n We continue with: <pre><code class=\"language-python\">$ n.requires_grad_(True) \n$ n.backward()</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "`tensor([0., 0., 0., 16., 0.])`",
     "`tensor([0., 0., 0., 32., 0.])`"
@@ -77,7 +77,7 @@ There is an error when at `n.backward()`: `RuntimeError: Trying to backward thro
 
 [[questions]]
 type = "MultipleChoice"
-prompt.prompt = "We continue with: <pre><code class=\"language-python\"> $ m.requires_grad_(True) \n$ m.backward()</code></pre>\n What is the output of `print(b.grad)`?"
+prompt.prompt = "We run the following code: <pre><code class=\"language-python\">$ b = torch.tensor([1, 1, 1, 5, 1], dtype=torch.float)\n$ b.requires_grad_(True) \ntensor([1., 1., 1., 5., 1.], requires_grad=True)\n$ l = sum((b-1)**2) \n$ l.backward() \n$ print(l) \ntensor(16., grad_fn=<AddBackward0>) \n$ m = sum((b.data -1)**2) \n$ n = sum((b-1)**2) \n$ n.backward() \n$ n.requires_grad_(True) \n$ n.backward()</code></pre>\n We continue with: <pre><code class=\"language-python\">$ m.requires_grad_(True) \n$ m.backward()</code></pre>\n What is the output of `print(b.grad)`?"
 prompt.choices = [
     "there is an error at `m.backward()`",
     "`tensor([0., 0., 0., 8., 0.])`",


### PR DESCRIPTION
In quiz 2, you can't see or come back to previous questions (when answering to Q2/2, you can't see Q1/2), which is problematic when the answer to Q2/2 relies on a variable defined in Q1/2.

To fix this, I repeat the code of previous questions.

![image](https://user-images.githubusercontent.com/15524303/211594875-3cf405dc-5351-4801-8159-c81b6bebbf73.png)
